### PR TITLE
Fix to event permissions, now all users should be able to create even…

### DIFF
--- a/markdown/patch_notes.md
+++ b/markdown/patch_notes.md
@@ -4,3 +4,4 @@ Dollar 1.1.2 aims to eliminate additional pesky bugs to enhance the user experie
 
 **Fixes:**
 - Fix to MySQL connection timing out, last attempt at a validation query would cause Dollar's terminal to freeze due to threads not being cleaned up. Refactored to use tasks.loop rather than manually creating a thread. Tasks.loop run in the background of the main event thread and is essentially the same creating a thread for this task.
+- Fix to Event permissions, now users are granted access to Shows📺 by default. If you create and start an event, 'interested' users will be given access to join the channel when the event starts, while restricting access for everone who is 'uninterested'

--- a/music.py
+++ b/music.py
@@ -427,13 +427,14 @@ async def on_scheduled_event_update(before, after):
             mentioned_users.append(user.mention)
             logger.info(f'{user} is interested, allowing them to connect to {channel}')
         mention_string = ' '.join(mentioned_users)
-        await channel.send(f"The event [{after.name}] has started! {mention_string}, you can now join the voice channel.")
+        await channel.send(f"The event, {after.name} has started! {mention_string}, you can now join the voice channel.")
+        await channel.set_permissions(channel.guild.default_role, connect=False)
     elif start == 'EventStatus.active' and current == 'EventStatus.completed':
         #Event has completed
         logger.info(f'Event [{after.name}] in {after.guild} has completed')
         await channel.edit(sync_permissions=True)
-        await channel.set_permissions(channel.guild.default_role, connect=False)
-        logger.info(f'Revoked access to {channel} for all users')
+        await channel.set_permissions(channel.guild.default_role, connect=True)
+        logger.info(f'Reset channel permissions and granted access to {channel} for all users')
 
 # Add interested users to connect to event channel
 @client.event


### PR DESCRIPTION
…ts as well as made a better workflow for events starting. Destroy the branch after reviewing.

Changes were made to event methods found in the image below. By default all users will have access to join the voice channel, when the event starts only the interested users will have access to join. When the event ends, all users will be given access again.
![image](https://github.com/aaronrai24/DollarDiscordBot/assets/55159220/53a2b93e-4cf2-4a45-aeb2-21682383cd19)
